### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ryo8000/simple-mock-server/security/code-scanning/1](https://github.com/ryo8000/simple-mock-server/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs read operations (e.g., checking out the repository and running tests), we will set `contents: read` as the minimal required permission. This ensures the workflow has the least privileges necessary to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
