### PR TITLE
feat: Add health check for container monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN yarn build
 
 FROM node:22.15.0-slim AS production
 ENV NODE_ENV=production
+ENV PORT=8000
 
 # Create non-root user for security
 RUN addgroup --system nodejs && \
@@ -26,5 +27,9 @@ COPY --from=build /app/dist ./dist
 # Install only production dependencies
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile --production && yarn cache clean
+
+# Health check for container monitoring
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD node -e "require('http').get('http://localhost:${PORT:-8000}/', (res) => { process.exit(res.statusCode === 200 ? 0 : 1) }).on('error', () => process.exit(1))"
 
 CMD ["node", "dist/server.js"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Set the default server port to 8000 in the production environment.
  * Added automated health checks to monitor container status and ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->