### PR TITLE
Fix typo in README shutdown endpoint description,

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Built with **Node.js** and **Express**.
 | `ALL`  | `/mirror/`               | Returns the request body as a response.                                                                      |
 | `ALL`  | `/redirect/`             | Returns a redirect response based on the `status` and `url` of the query parameters.                         |
 | `ALL`  | `/request/`              | Return a structured JSON dump of the incoming request.                                                       |
-| `ALL`  | `/shutdown/`             | GTriggers a shutdown of the server. Requires `ENABLE_SHUTDOWN=true`.                                         |
+| `ALL`  | `/shutdown/`             | Triggers a shutdown of the server. Requires `ENABLE_SHUTDOWN=true`.                                         |
 | `ALL`  | `/status/{status}`       | Respond with arbitrary HTTP status.                                                                          |
 | `ALL`  | `/uuid/`                 | Generate and return a random UUID (version 4).                                                               |
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo and clarified the description of the /shutdown endpoint in the README.
  * Explicitly notes the ENABLE_SHUTDOWN=true requirement for using the endpoint.
  * No functional changes; behavior, control flow, and error handling remain the same.
  * Improves accuracy, readability, and consistency across documentation.
  * Reduces potential confusion for users configuring and managing server shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->