### PR TITLE
Fix formatting in permissions for Bash commands in settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,11 +2,11 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
-      "Bash(git add:*)",
-      "Bash(git fetch:*)",
-      "Bash(ls:*)",
+      "Bash(git add *)",
+      "Bash(git fetch *)",
+      "Bash(ls *)",
       "Bash(node dist/server.js)",
-      "Bash(yarn install:*)",
+      "Bash(yarn install *)",
       "Bash(yarn dev)",
       "Bash(yarn build)",
       "Bash(yarn test)",
@@ -17,17 +17,17 @@
       "Bash(yarn format:*)"
     ],
     "ask": [
-      "Bash(git commit:*)",
-      "Bash(git push:*)",
-      "Bash(yarn add:*)",
-      "Bash(yarn remove:*)"
+      "Bash(git commit *)",
+      "Bash(git push *)",
+      "Bash(yarn add *)",
+      "Bash(yarn remove *)"
     ],
     "deny": [
       "Bash(rm -rf /)",
       "Bash(rm -rf ~)",
       "Bash(rm -rf ~/*)",
       "Bash(rm -rf /*)",
-      "Bash(sudo:*)",
+      "Bash(sudo *)",
       "Read(./.env)",
       "Read(./.env.*)"
     ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,9 +3,12 @@
   "permissions": {
     "allow": [
       "Bash(git add *)",
+      "Bash(git fetch)",
       "Bash(git fetch *)",
+      "Bash(ls)",
       "Bash(ls *)",
       "Bash(node dist/server.js)",
+      "Bash(yarn install)",
       "Bash(yarn install *)",
       "Bash(yarn dev)",
       "Bash(yarn build)",
@@ -18,6 +21,7 @@
     ],
     "ask": [
       "Bash(git commit *)",
+      "Bash(git push)",
       "Bash(git push *)",
       "Bash(yarn add *)",
       "Bash(yarn remove *)"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated command permission patterns in configuration settings, transitioning from colon-based to space-based wildcard syntax and adjusting permission rules for system commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryo8000/http-playground-server/pull/343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->