### PR TITLE
fix: Update logger middleware to handle HEAD requests and log empty body

### DIFF
--- a/src/middlewares/logger.ts
+++ b/src/middlewares/logger.ts
@@ -16,7 +16,7 @@ export const loggerMiddleware = (req: Request, res: Response, next: NextFunction
       url: req.url,
       query: req.query,
       headers: req.headers,
-      body: req.method === 'GET' || req.method === 'HEAD' || req.body === undefined ? {} : req.body,
+      body: req.method === 'GET' || req.method === 'HEAD' ? {} : (req.body ?? {}),
     },
     'Incoming request',
   );

--- a/src/middlewares/logger.ts
+++ b/src/middlewares/logger.ts
@@ -16,7 +16,7 @@ export const loggerMiddleware = (req: Request, res: Response, next: NextFunction
       url: req.url,
       query: req.query,
       headers: req.headers,
-      body: req.method === 'GET' || req.body === undefined ? {} : req.body,
+      body: req.method === 'GET' || req.method === 'HEAD' || req.body === undefined ? {} : req.body,
     },
     'Incoming request',
   );

--- a/tests/ut/middlewares/logger.test.ts
+++ b/tests/ut/middlewares/logger.test.ts
@@ -90,4 +90,17 @@ describe('LoggerMiddleware', () => {
       'Incoming request',
     );
   });
+
+  it('should log empty body for HEAD requests', () => {
+    mockRequest.method = 'HEAD';
+
+    loggerMiddleware(mockRequest as Request, mockResponse as Response, mockNext);
+
+    expect(log.debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: {},
+      }),
+      'Incoming request',
+    );
+  });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced request logging to properly omit request body details for HEAD requests, ensuring consistent behavior with GET requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->