### PR TITLE
fix: Validate and set log level and node environment from environment variables

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -1,3 +1,22 @@
+const ALLOWED_LOG_LEVELS = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'] as const;
+type LogLevel = (typeof ALLOWED_LOG_LEVELS)[number];
+const ALLOWED_NODE_ENVS = ['development', 'production', 'test'] as const;
+type NodeEnv = (typeof ALLOWED_NODE_ENVS)[number];
+
+const logLevel = process.env['LOG_LEVEL'] ?? 'info';
+if (!(ALLOWED_LOG_LEVELS as readonly string[]).includes(logLevel)) {
+  throw new Error(
+    `Invalid configuration: LOG_LEVEL (${logLevel}) must be one of: ${ALLOWED_LOG_LEVELS.join(', ')}.`,
+  );
+}
+
+const nodeEnv = process.env['NODE_ENV'] ?? 'development';
+if (!(ALLOWED_NODE_ENVS as readonly string[]).includes(nodeEnv)) {
+  throw new Error(
+    `Invalid configuration: NODE_ENV (${nodeEnv}) must be one of: ${ALLOWED_NODE_ENVS.join(', ')}.`,
+  );
+}
+
 const headersTimeout = Number(process.env['HEADERS_TIMEOUT']) || 10000;
 const requestTimeout = Number(process.env['REQUEST_TIMEOUT']) || 30000;
 const keepAliveTimeout = Number(process.env['KEEP_ALIVE_TIMEOUT']) || 5000;
@@ -16,11 +35,11 @@ if (requestTimeout <= headersTimeout) {
 
 export const environment = {
   enableShutdown: process.env['ENABLE_SHUTDOWN'] === 'true',
+  logLevel: logLevel as LogLevel,
+  nodeEnv: nodeEnv as NodeEnv,
   headersTimeout,
   keepAliveTimeout,
-  logLevel: process.env['LOG_LEVEL'] || 'info',
   maxDelay: Number(process.env['MAX_DELAY']) || 10000,
-  nodeEnv: process.env['NODE_ENV'] || 'development',
   origin: process.env['ORIGIN'] || '*',
   port: Number(process.env['PORT']) || 8000,
   requestTimeout,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment settings now validate supported log level and runtime mode values at startup, helping catch invalid configuration earlier.
  * Default values are still applied when settings are not provided, while preserving existing timeout and delay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->