### PR TITLE
fix: Update Jest configuration to enable coverage collection and adjust test script

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -71,7 +71,7 @@ jobs:
         run: yarn lint
 
       - name: Run unit tests
-        run: yarn test
+        run: yarn test:coverage
 
       - name: Build application
         run: yarn build

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ export default {
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
-  collectCoverage: true,
+  collectCoverage: false,
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'html'],
   collectCoverageFrom: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,5 +12,14 @@ export default {
   },
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
-  }
+  },
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'html'],
+  collectCoverageFrom: [
+    'src/**/*.{js,jsx,ts,tsx}',
+    '!src/**/*.d.ts',
+    '!**/node_modules/**',
+    '!**/dist/**',
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "nodemon",
-    "test": "jest --coverage",
+    "test": "jest",
     "test:e2e": "newman run tests/e2e/e2e-test-collection.json -e tests/e2e/environment.json --reporters cli",
     "lint": "eslint src tests",
     "lint:fix": "eslint src tests --fix",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "tsc",
     "dev": "nodemon",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:e2e": "newman run tests/e2e/e2e-test-collection.json -e tests/e2e/environment.json --reporters cli",
     "lint": "eslint src tests",
     "lint:fix": "eslint src tests --fix",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test settings to automatically collect code coverage and generate reports in multiple formats.
  * Coverage results are now saved in a dedicated output folder and focus on source files only.

* **Tests**
  * Simplified the main test command so it runs tests without generating coverage every time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->