### PR TITLE
chore: add Codespaces demo configuration for trying the endpoints

### DIFF
--- a/.devcontainer/demo/devcontainer.json
+++ b/.devcontainer/demo/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "HTTP Playground (try the endpoints)",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
+
+  "postCreateCommand": "yarn install --frozen-lockfile",
+  "postAttachCommand": "yarn dev",
+
+  // Enabled so these endpoints can actually be tried; each Codespace is disposable.
+  // They stop the server process, and nodemon does not restart after a crash, so the
+  // server has to be brought back with `yarn dev`.
+  "remoteEnv": {
+    "ENABLE_CRASH": "true",
+    "ENABLE_SHUTDOWN": "true"
+  },
+
+  "forwardPorts": [8000],
+  "portsAttributes": {
+    "8000": {
+      "label": "HTTP Playground Server",
+      "onAutoForward": "notify"
+    }
+  }
+}

--- a/.devcontainer/demo/devcontainer.json
+++ b/.devcontainer/demo/devcontainer.json
@@ -2,13 +2,17 @@
   "name": "HTTP Playground (try the endpoints)",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
 
+  // waitFor defaults to updateContentCommand, which lets the attach hook run mid-install.
+  "waitFor": "postCreateCommand",
   "postCreateCommand": "yarn install --frozen-lockfile",
-  "postAttachCommand": "yarn dev",
 
-  // Enabled so these endpoints can actually be tried; each Codespace is disposable.
-  // They stop the server process, and nodemon does not restart after a crash, so the
-  // server has to be brought back with `yarn dev`.
+  // The attach hook runs on every reconnect, hence the guard. `serve` rather than `dev`
+  // because a nodemon watcher survives /crash and would pile up on every restart.
+  "postAttachCommand": "curl -sf -o /dev/null http://localhost:8000/ || yarn serve",
+
+  // Enabled because each Codespace is disposable and isolated per user.
   "remoteEnv": {
+    "LOG_LEVEL": "debug",
     "ENABLE_CRASH": "true",
     "ENABLE_SHUTDOWN": "true"
   },

--- a/README.md
+++ b/README.md
@@ -9,6 +9,39 @@ Built with **Node.js** and **Express**.
 
 ---
 
+## ⚡ Try It Instantly
+
+### In your browser, with GitHub Codespaces
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/ryo8000/http-playground-server?devcontainer_path=.devcontainer%2Fdemo%2Fdevcontainer.json)
+
+The badge opens a Codespace with the **HTTP Playground** configuration, which starts the server on port `8000` automatically. Send requests straight from the terminal:
+
+```bash
+curl -i localhost:8000/status/418
+curl -i localhost:8000/request
+curl -sv localhost:8000/reset
+```
+
+> [!TIP]
+> Use `localhost:8000` from the terminal rather than the forwarded `*.app.github.dev` URL. The forwarded URL goes through an HTTP proxy, which normalizes the connection-level behavior that endpoints like `/reset`, `/keep-alive-cut`, `/truncate`, and `/infinite` exist to demonstrate.
+
+`/crash` and `/shutdown` are enabled in the Codespace, and they really do stop the server process. Nothing else is affected — the Codespace is yours alone — but the server will not come back on its own. Restart it with:
+
+```bash
+yarn dev
+```
+
+### On your machine, with the published image
+
+```bash
+docker run --rm -p 8000:8000 ghcr.io/ryo8000/http-playground-server:latest
+```
+
+Add `-e ENABLE_SHUTDOWN=true -e ENABLE_CRASH=true` to enable those endpoints.
+
+---
+
 ## 📚 API Reference
 
 | Method | Path                    | Description                                                                                                            |
@@ -85,6 +118,8 @@ Built with **Node.js** and **Express**.
 ## 🚀 Build and Run the Application
 
 ### Using Docker
+
+Builds the image from source. To run the published image instead, see [Try It Instantly](#-try-it-instantly).
 
 1. Clone this repository:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ curl -sv localhost:8000/reset
 `/crash` and `/shutdown` are enabled in the Codespace, and they really do stop the server process. Nothing else is affected — the Codespace is yours alone — but the server will not come back on its own. Restart it with:
 
 ```bash
-yarn dev
+yarn serve
 ```
 
 ### On your machine, with the published image
@@ -38,7 +38,14 @@ yarn dev
 docker run --rm -p 8000:8000 ghcr.io/ryo8000/http-playground-server:latest
 ```
 
-Add `-e ENABLE_SHUTDOWN=true -e ENABLE_CRASH=true` to enable those endpoints.
+To enable `/crash` and `/shutdown`, pass the flags before the image name:
+
+```bash
+docker run --rm -p 8000:8000 \
+  -e ENABLE_SHUTDOWN=true \
+  -e ENABLE_CRASH=true \
+  ghcr.io/ryo8000/http-playground-server:latest
+```
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "nodemon",
+    "serve": "tsx src/server.ts",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "jest",


### PR DESCRIPTION
Add .devcontainer/demo/devcontainer.json, a second dev container that installs dependencies and starts the server on port 8000 automatically, so visitors can try the endpoints without any local setup. ENABLE_CRASH and ENABLE_SHUTDOWN are enabled there because each Codespace is disposable and isolated per user.

Document it in the README together with a docker run one-liner for the image already published to ghcr.io. Note that connection-level endpoints such as /reset and /truncate should be called through localhost:8000 rather than the forwarded URL, which normalizes that behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a ready-to-use GitHub Codespaces environment for the HTTP playground.
  * Added automatic dependency installation, development-server startup, crash handling, and port forwarding.
  * Added a `serve` command for launching the TypeScript server.

* **Documentation**
  * Added instructions for trying the playground instantly through Codespaces.
  * Documented example requests, connection behavior, server restarts, destructive endpoints, and running the published Docker image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->