### PR TITLE
chore: let yarn dev enable every endpoint

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -4,12 +4,7 @@
   "exec": "tsx ./src/server.ts",
   "env": {
     "LOG_LEVEL": "debug",
-    "KEEP_ALIVE_TIMEOUT": 5000,
-    "HEADERS_TIMEOUT": 10000,
-    "REQUEST_TIMEOUT": 30000,
-    "ENABLE_SHUTDOWN": true,
-    "MAX_DELAY": 10000,
-    "ORIGIN": "*",
-    "PORT": 8000
+    "ENABLE_CRASH": true,
+    "ENABLE_SHUTDOWN": true
   }
 }

--- a/tests/e2e/e2e-test-collection.json
+++ b/tests/e2e/e2e-test-collection.json
@@ -1126,35 +1126,6 @@
       ]
     },
     {
-      "name": "Crash - Not Enabled",
-      "request": {
-        "method": "GET",
-        "header": [],
-        "url": {
-          "raw": "{{baseUrl}}/crash",
-          "host": ["{{baseUrl}}"],
-          "path": ["crash"]
-        }
-      },
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Status code is 403', function () {",
-              "    pm.response.to.have.status(403);",
-              "});",
-              "",
-              "pm.test('Response has error message', function () {",
-              "    const jsonData = pm.response.json();",
-              "    pm.expect(jsonData.error.message).to.equal('Crash is not enabled');",
-              "});"
-            ]
-          }
-        }
-      ]
-    },
-    {
       "name": "Rate Limit - Request 1 Allowed",
       "request": {
         "method": "GET",


### PR DESCRIPTION
Add ENABLE_CRASH to nodemon.json so the development server enables /crash as well as /shutdown, and drop the env values that only repeated the fallbacks in src/env.ts: KEEP_ALIVE_TIMEOUT, HEADERS_TIMEOUT, REQUEST_TIMEOUT, MAX_DELAY, ORIGIN and PORT.

Remove the "Crash - Not Enabled" case from the e2e collection, which assumed the opposite. tests/ut/routes/crash.test.ts already covers both the enabled and the disabled path across every HTTP method, including the process.exit call, so the e2e case only repeated the weaker half of it. It was also the one case whose result depended on a server-wide flag: against a server with ENABLE_CRASH=true it killed the server mid-suite, turning a single mismatch into 40 unrelated failures.

The suite now passes against both `yarn dev` and `node dist/server.js`.