### PR TITLE
fix: report /request cookies exactly as sent

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,12 @@
     "verify": "yarn format:check && yarn lint && yarn typecheck"
   },
   "dependencies": {
-    "cookie-parser": "1.4.7",
     "cors": "2.8.6",
     "express": "5.2.1",
     "pino": "10.3.1"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
-    "@types/cookie-parser": "1.4.10",
     "@types/cors": "2.8.19",
     "@types/express": "5.0.6",
     "@types/jest": "30.0.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,4 @@
 import express from 'express';
-import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import { delayMiddleware } from './middlewares/delay.js';
 import { loggerMiddleware } from './middlewares/logger.js';
@@ -49,7 +48,6 @@ app.use(
     allowedHeaders: ['Authorization', 'Content-Type'],
   }),
 );
-app.use(cookieParser());
 app.use(loggerMiddleware);
 app.use(delayMiddleware);
 

--- a/src/routes/request.ts
+++ b/src/routes/request.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { parseCookieHeader } from '../utils/cookies.js';
 
 const requestRouter = Router();
 
@@ -12,7 +13,7 @@ requestRouter.all('/', (req, res) => {
     query: req.query,
     headers: req.headers,
     body: req.method === 'GET' || req.body === undefined ? {} : req.body,
-    cookies: req.cookies,
+    cookies: parseCookieHeader(req.headers.cookie),
   });
 });
 

--- a/src/services/cookies.ts
+++ b/src/services/cookies.ts
@@ -1,3 +1,4 @@
+import { parseCookieHeader } from '../utils/cookies.js';
 import { HttpStatusCodes } from '../utils/http.js';
 
 // RFC 6265 cookie-name characters (HTTP token)
@@ -26,53 +27,15 @@ const badRequest = (message: string): InvalidCookieResult => ({
 });
 
 /**
- * Decodes a cookie value, unwrapping the optional double quotes around it.
- *
- * @param value - The raw value from the Cookie header.
- * @returns The decoded value, or the raw one when the percent-encoding is
- *   malformed (`decodeURIComponent` throws on e.g. '%zz').
- */
-const decodeCookieValue = (value: string): string => {
-  const unquoted = value.startsWith('"') && value.endsWith('"') ? value.slice(1, -1) : value;
-
-  try {
-    return decodeURIComponent(unquoted);
-  } catch {
-    return unquoted;
-  }
-};
-
-/**
- * Parses a Cookie request header into the name/value pairs it carries.
- *
- * Deliberately parsed here rather than read from cookie-parser's `req.cookies`:
- * that drops a cookie named '__proto__' and turns 'j:'-prefixed values into
- * objects, so the endpoint would not report what the client actually sent.
+ * Reads the cookies carried by a Cookie request header.
  *
  * @param header - The raw Cookie header, absent when the request sent none.
- * @returns A result with one entry per cookie, the first occurrence winning.
+ * @returns A result with one entry per cookie.
  */
-export const readCookies = (header: string | undefined): ReadCookiesResult => {
-  const cookies: Record<string, string> = Object.create(null);
-
-  for (const pair of header?.split(';') ?? []) {
-    const separator = pair.indexOf('=');
-
-    if (separator < 0) {
-      continue;
-    }
-
-    const name = pair.slice(0, separator).trim();
-
-    if (name === '' || Object.prototype.hasOwnProperty.call(cookies, name)) {
-      continue;
-    }
-
-    cookies[name] = decodeCookieValue(pair.slice(separator + 1).trim());
-  }
-
-  return { status: HttpStatusCodes.OK, body: { cookies } };
-};
+export const readCookies = (header: string | undefined): ReadCookiesResult => ({
+  status: HttpStatusCodes.OK,
+  body: { cookies: parseCookieHeader(header) },
+});
 
 /**
  * Validates query parameters as cookie name/value pairs to set.

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -1,0 +1,56 @@
+/**
+ * Decodes a cookie value, unwrapping the optional double quotes around it.
+ *
+ * @param value - The raw value from the Cookie header.
+ * @returns The decoded value, or the raw one when the percent-encoding is
+ *   malformed (`decodeURIComponent` throws on e.g. '%zz').
+ */
+const decodeCookieValue = (value: string): string => {
+  const unquoted = value.startsWith('"') && value.endsWith('"') ? value.slice(1, -1) : value;
+
+  try {
+    return decodeURIComponent(unquoted);
+  } catch {
+    return unquoted;
+  }
+};
+
+/**
+ * Parses a Cookie request header into the name/value pairs it carries.
+ *
+ * Parsed here rather than with the usual cookie/cookie-parser middleware: those
+ * drop a cookie named '__proto__' and turn 'j:'-prefixed values into objects, so
+ * an endpoint would not report what the client actually sent.
+ *
+ * `cookie` v1.0.0 fixed the '__proto__' half upstream by returning a
+ * null-prototype object, but express 5.2.1 depends on `cookie` ^0.7.1, which
+ * still drops it. Once express moves to `cookie` 2.x, drop this function and
+ * call that `parse` instead — the tests in tests/ut/utils/cookies.test.ts
+ * describe the behavior it has to keep.
+ *
+ * @param header - The raw Cookie header, absent when the request sent none.
+ * @returns One entry per cookie, the first occurrence of a name winning.
+ */
+export const parseCookieHeader = (header: string | undefined): Record<string, string> => {
+  // Null-prototype so a cookie named '__proto__' is stored instead of silently
+  // hitting Object.prototype's setter.
+  const cookies: Record<string, string> = Object.create(null);
+
+  for (const pair of header?.split(';') ?? []) {
+    const separator = pair.indexOf('=');
+
+    if (separator < 0) {
+      continue;
+    }
+
+    const name = pair.slice(0, separator).trim();
+
+    if (name === '' || Object.prototype.hasOwnProperty.call(cookies, name)) {
+      continue;
+    }
+
+    cookies[name] = decodeCookieValue(pair.slice(separator + 1).trim());
+  }
+
+  return cookies;
+};

--- a/tests/e2e/e2e-test-collection.json
+++ b/tests/e2e/e2e-test-collection.json
@@ -387,6 +387,10 @@
           {
             "key": "X-Test-Header",
             "value": "test-value"
+          },
+          {
+            "key": "Cookie",
+            "value": "e2e=1; json=j%3A%7B%22x%22%3A1%7D"
           }
         ],
         "url": {
@@ -422,6 +426,11 @@
               "    pm.expect(jsonData).to.have.property('body');",
               "    pm.expect(jsonData).to.have.property('cookies');",
               "    pm.expect(jsonData.query).to.have.property('test', 'param');",
+              "});",
+              "",
+              "pm.test('Cookies are reported as sent', function () {",
+              "    var jsonData = pm.response.json();",
+              "    pm.expect(jsonData.cookies).to.eql({ e2e: '1', json: 'j:{\"x\":1}' });",
               "});"
             ]
           }

--- a/tests/ut/routes/cookies.test.ts
+++ b/tests/ut/routes/cookies.test.ts
@@ -1,10 +1,8 @@
 import express from 'express';
-import cookieParser from 'cookie-parser';
 import request from 'supertest';
 import { cookiesRouter } from '../../../src/routes/cookies.js';
 
 const app = express();
-app.use(cookieParser());
 app.use('/cookies', cookiesRouter);
 
 const HTTP_METHODS = ['get', 'post', 'put', 'delete', 'patch', 'head', 'options'] as const;

--- a/tests/ut/routes/request.test.ts
+++ b/tests/ut/routes/request.test.ts
@@ -1,12 +1,10 @@
 import express from 'express';
-import cookieParser from 'cookie-parser';
 import request from 'supertest';
 import { requestRouter } from '../../../src/routes/request.js';
 
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
-app.use(cookieParser());
 app.use('/request', requestRouter);
 
 const BODY_METHODS = ['post', 'put', 'delete', 'patch', 'options'] as const;
@@ -62,6 +60,15 @@ describe('requestRouter', () => {
       protocol: expect.any(String),
       host: expect.any(String),
     });
+  });
+
+  it('should respond with the cookies exactly as sent', async () => {
+    const res = await request(app)
+      .get('/request')
+      .set('Cookie', '__proto__=abc; a=j%3A%7B%22x%22%3A1%7D');
+
+    expect(res.status).toBe(200);
+    expect(res.body.cookies).toEqual({ ['__proto__']: 'abc', a: 'j:{"x":1}' });
   });
 
   it('should return 200 for head', async () => {

--- a/tests/ut/services/cookies.test.ts
+++ b/tests/ut/services/cookies.test.ts
@@ -1,30 +1,16 @@
 import { deleteCookies, readCookies, setCookies } from '../../../src/services/cookies.js';
 
-const parseCases: [string, string | undefined, Record<string, string>][] = [
-  ['a single pair', 'flavor=chocolate', { flavor: 'chocolate' }],
-  [
-    'multiple pairs',
-    'flavor=chocolate; session=abc123',
-    { flavor: 'chocolate', session: 'abc123' },
-  ],
-  ['no header', undefined, {}],
-  ['an empty value', 'flavor=', { flavor: '' }],
-  ['a percent-encoded value', 'flavor=chocolate%20chip', { flavor: 'chocolate chip' }],
-  ['a quoted value', 'flavor="chocolate"', { flavor: 'chocolate' }],
-  ['a malformed percent-encoded value', 'flavor=%zz', { flavor: '%zz' }],
-  ["a cookie named '__proto__'", '__proto__=abc', { ['__proto__']: 'abc' }],
-  ["a 'j:'-prefixed value as a string", 'a=j%3A%7B%22x%22%3A1%7D', { a: 'j:{"x":1}' }],
-  [
-    'a repeated name, keeping the first',
-    'flavor=chocolate; flavor=vanilla',
-    { flavor: 'chocolate' },
-  ],
-  ['an entry without a value', 'flavor', {}],
-];
-
 describe('readCookies', () => {
-  it.each(parseCases)('should parse %s', (_description, header, cookies) => {
-    expect(readCookies(header)).toEqual({ status: 200, body: { cookies } });
+  it('should return the cookies carried by the header', () => {
+    const result = readCookies('flavor=chocolate; session=abc123');
+    expect(result).toEqual({
+      status: 200,
+      body: { cookies: { flavor: 'chocolate', session: 'abc123' } },
+    });
+  });
+
+  it('should return an empty object when there is no header', () => {
+    expect(readCookies(undefined)).toEqual({ status: 200, body: { cookies: {} } });
   });
 });
 

--- a/tests/ut/utils/cookies.test.ts
+++ b/tests/ut/utils/cookies.test.ts
@@ -1,0 +1,29 @@
+import { parseCookieHeader } from '../../../src/utils/cookies.js';
+
+const parseCases: [string, string | undefined, Record<string, string>][] = [
+  ['a single pair', 'flavor=chocolate', { flavor: 'chocolate' }],
+  [
+    'multiple pairs',
+    'flavor=chocolate; session=abc123',
+    { flavor: 'chocolate', session: 'abc123' },
+  ],
+  ['no header', undefined, {}],
+  ['an empty value', 'flavor=', { flavor: '' }],
+  ['a percent-encoded value', 'flavor=chocolate%20chip', { flavor: 'chocolate chip' }],
+  ['a quoted value', 'flavor="chocolate"', { flavor: 'chocolate' }],
+  ['a malformed percent-encoded value', 'flavor=%zz', { flavor: '%zz' }],
+  ["a cookie named '__proto__'", '__proto__=abc', { ['__proto__']: 'abc' }],
+  ["a 'j:'-prefixed value as a string", 'a=j%3A%7B%22x%22%3A1%7D', { a: 'j:{"x":1}' }],
+  [
+    'a repeated name, keeping the first',
+    'flavor=chocolate; flavor=vanilla',
+    { flavor: 'chocolate' },
+  ],
+  ['an entry without a value', 'flavor', {}],
+];
+
+describe('parseCookieHeader', () => {
+  it.each(parseCases)('should parse %s', (_description, header, cookies) => {
+    expect(parseCookieHeader(header)).toEqual(cookies);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -931,11 +931,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/cookie-parser@1.4.10":
-  version "1.4.10"
-  resolved "https://registry.yarnpkg.com/@types/cookie-parser/-/cookie-parser-1.4.10.tgz#a045272a383a30597a01955d4f9c790018f214e4"
-  integrity sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==
-
 "@types/cookiejar@^2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.5.tgz#14a3e83fa641beb169a2dd8422d91c3c345a9a78"
@@ -1806,25 +1801,12 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-cookie-parser@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.7.tgz#e2125635dfd766888ffe90d60c286404fa0e7b26"
-  integrity sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==
-  dependencies:
-    cookie "0.7.2"
-    cookie-signature "1.0.6"
-
-cookie-signature@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
-  integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
-
 cookie-signature@^1.2.1, cookie-signature@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.2.2.tgz#57c7fc3cc293acab9fec54d73e15690ebe4a1793"
   integrity sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==
 
-cookie@0.7.2, cookie@^0.7.1:
+cookie@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==


### PR DESCRIPTION
/request built its cookies field from cookie-parser's req.cookies, which drops a cookie named proto and turns 'j:'-prefixed values into parsed objects. The endpoint reported something the client never sent, which is the same gap /cookies had before it started parsing the header itself.

Extract that parsing into src/utils/cookies.ts as parseCookieHeader and call it from both /request and the cookies service. cookie-parser is left with no readers, so drop the middleware and the dependency.

The proto half is fixed upstream in cookie v1.0.0, but express 5.2.1 depends on cookie ^0.7.1, so the local parser stays until express moves to cookie 2.x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added robust cookie-header parsing, including URL-decoded and quoted values.
  * Preserves duplicate-cookie behavior and safely handles special cookie names and malformed entries.
* **Bug Fixes**
  * Request and cookie endpoints now consistently read cookies directly from incoming headers.
  * Cookie values are returned accurately without unintended parsing or data loss.
* **Tests**
  * Expanded coverage for encoded, quoted, malformed, duplicate, empty, and special-name cookies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->